### PR TITLE
Fixed error when '#' is included in address, allow passing arguments …

### DIFF
--- a/src/RDSTK/R/functions.R
+++ b/src/RDSTK/R/functions.R
@@ -9,9 +9,9 @@
   }
 }
 
-street2coordinates <- function(address, session=getCurlHandle()) {
+street2coordinates <- function(address, session=getCurlHandle(), ...) {
   api <- paste(getOption("RDSTK_api_base"), "/street2coordinates/", sep="")
-  get.addy <- getURL(paste(api, URLencode(address), sep=""), curl=session)
+  get.addy <- getURL(paste(api, URLencode(address, reserved = TRUE), sep=""), curl=session, ...)
   clean.addy <- lapply(fromJSON(get.addy), 
                       lapply, 
                       function(x) ifelse(is.null(x), NA, x))


### PR DESCRIPTION
Added argument to URLencode which cleans up reserved characters before making the request, which prevents errors if the address includes a reserved character.

Additionally, added "..." to the street2coordinates function which allows additional arguments to be passed to getURL for debugging a failed API call.
